### PR TITLE
Take public keys from URL parameter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -147,7 +147,7 @@
                   </div>
 
                   <div class="card mb-3">
-                    <div class="card-header">Public key</div>
+                    <div class="card-header">Public key <a id="pubkey-share" title="Shareable link (supports multiple comma-separated keys)" class="text-decoration-none" target="_blank" hidden="true">&nbsp;&#x1F517;</a></div>
                     <div class="card-body">
                       <textarea
                         class="form-control message"

--- a/src/main.js
+++ b/src/main.js
@@ -62,9 +62,12 @@ document
     e.preventDefault();
     let pubkey = document.getElementById("pubkey");
     let privkey = document.getElementById("privkey");
+    let pubshare = document.getElementById("pubkey-share");
     const keys = generateX25519Identity();
     pubkey.value = keys.publicKey;
     privkey.value = keys.privateKey;
+    pubshare.removeAttribute("hidden");
+    pubshare.setAttribute("href", `/?pubkey=${keys.publicKey}`);
   });
 
 document.getElementById("encryptForm").addEventListener("submit", function (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -175,3 +175,18 @@ document
       reader.readAsArrayBuffer(f);
     }
   });
+
+document.addEventListener("DOMContentLoaded", function() {
+  const params = new URLSearchParams(window.location.search);
+  const pubkey = params.get("pubkey");
+  if (pubkey) {
+    const encTab = document.getElementById("encrypt-tab");
+    const reciText = document.getElementById("recipients");
+    const reciBin = document.getElementById("recipients-binary");
+    const message = document.getElementById("message");
+    encTab.click();
+    reciText.value = pubkey.replaceAll(",", "\n");
+    reciBin.value = pubkey.replaceAll(",", "\n");
+    message.focus();
+  }
+});


### PR DESCRIPTION
Inspired by the `?r=` parameter in [Age Online](https://age-online.nkcmr.dev/), this PR adds the following functionality:

- After a keypair is generated, a share button (🔗) appears near the "Public key" header, which links to a URL containing the public key;
- A comma-separated list of public keys is taken from the `pubkey` parameter and used in both `Encrypt` and `Encrypt Binary` pages;
- If the parameter is present, the `Encrypt` page is automatically activated and the `Message` text area is focused.

#### Example URL
`https://agewasm.marin-basic.com/?pubkey=age10hy59pns469dreyrxwyrshzv62f5zt6q23snr4zg09n97s872upq2et4jq`

#### Notes
- The new line character, encoded as `%0A`, can be used instead of commas (`key1%0Akey2`)
- All domains should be supported, since the share button links to `/?pubkey=age1…`
- Tested in Brave and Firefox