### PR TITLE
Select read-only text areas on focus

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -142,6 +142,7 @@
                         placeholder="Your private key will be generated here."
                         id="privkey"
                         readonly="readonly"
+                        onclick="this.select()"
                       ></textarea>
                     </div>
                   </div>
@@ -156,6 +157,7 @@
                         placeholder="Your public key will be generated here."
                         id="pubkey"
                         readonly="readonly"
+                        onclick="this.select()"
                       ></textarea>
                     </div>
                   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -217,6 +217,7 @@
                         placeholder="Encrypted output will be generated here"
                         id="encryptedOutput"
                         readonly
+                        onclick="this.select()"
                       ></textarea>
                     </div>
                   </div>
@@ -335,6 +336,7 @@
                         placeholder="Decrypted output will be generated here"
                         id="decryptedOutput"
                         readonly
+                        onclick="this.select()"
                       ></textarea>
                     </div>
                   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -142,7 +142,7 @@
                         placeholder="Your private key will be generated here."
                         id="privkey"
                         readonly="readonly"
-                        onclick="this.select()"
+                        onfocus="this.select()"
                       ></textarea>
                     </div>
                   </div>
@@ -157,7 +157,7 @@
                         placeholder="Your public key will be generated here."
                         id="pubkey"
                         readonly="readonly"
-                        onclick="this.select()"
+                        onfocus="this.select()"
                       ></textarea>
                     </div>
                   </div>
@@ -217,7 +217,7 @@
                         placeholder="Encrypted output will be generated here"
                         id="encryptedOutput"
                         readonly
-                        onclick="this.select()"
+                        onfocus="this.select()"
                       ></textarea>
                     </div>
                   </div>
@@ -336,7 +336,7 @@
                         placeholder="Decrypted output will be generated here"
                         id="decryptedOutput"
                         readonly
-                        onclick="this.select()"
+                        onfocus="this.select()"
                       ></textarea>
                     </div>
                   </div>


### PR DESCRIPTION
It is common to automatically select the whole contents of read-only text areas when clicking them, so I've added this functionality here too:

https://github.com/user-attachments/assets/06ac6f01-8a96-4ba0-99fa-7cb635d20681

#### Affected elements:
- `#privkey`
- `#pubkey`
- `#encryptedOutput`
- `#decryptedOutput`